### PR TITLE
Set nodeintegration to true to ensure compatibility with Electron 5.0

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ let mainWindowTwo
 
 function createWindow() {
   // Create the browser window.
-  mainWindow = new BrowserWindow({ width: 860, height: 795 })
+  mainWindow = new BrowserWindow({ width: 860, height: 795, webPreferences: { nodeIntegration: true } })
 
   // and load the index.html of the app.
   mainWindow.loadURL(url.format({
@@ -40,7 +40,7 @@ function createWindow() {
 
 function createWindowTwo() {
   // Create the browser window.
-  mainWindowTwo = new BrowserWindow({ width: 1280, height: 720 })
+  mainWindowTwo = new BrowserWindow({ width: 1280, height: 720, webPreferences: { nodeIntegration: true } })
 
   // and load the index.html of the app.
   mainWindowTwo.loadURL(url.format({


### PR DESCRIPTION
Electron 5.0 now defaults `nodeIntegration` to `false` to prevent windowed websites from breaking out of their container. This small change will ensure that the two windows can communicate with each other when using Electron 5. It won't affect anything else.
[https://electronjs.org/blog/electron-5-0#security-improvements](https://electronjs.org/blog/electron-5-0#security-improvements)

You might also want to consider running `npm audit fix --force` to update your packages and fix security stuff.

Have a good day!